### PR TITLE
Validate Google Sheets environment variables in API route

### DIFF
--- a/app/api/sheets/route.ts
+++ b/app/api/sheets/route.ts
@@ -1,24 +1,53 @@
 import { google } from "googleapis";
 import { NextResponse } from "next/server";
 
-const auth = new google.auth.GoogleAuth({
-  credentials: {
-    client_email: process.env.GOOGLE_CLIENT_EMAIL,
-    private_key: process.env.GOOGLE_PRIVATE_KEY?.replace(/\\n/g, "\n"),
-  },
-  scopes: ["https://www.googleapis.com/auth/spreadsheets"],
-});
-
-const sheets = google.sheets({ version: "v4", auth });
-
 export async function POST(request: Request) {
+  const clientEmail = process.env.GOOGLE_CLIENT_EMAIL;
+  const privateKeyRaw = process.env.GOOGLE_PRIVATE_KEY;
+  const sheetId = process.env.GOOGLE_SHEET_ID;
+
+  const missing = [
+    !clientEmail && "GOOGLE_CLIENT_EMAIL",
+    !privateKeyRaw && "GOOGLE_PRIVATE_KEY",
+    !sheetId && "GOOGLE_SHEET_ID",
+  ].filter(Boolean) as string[];
+
+  if (missing.length > 0) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: `Missing environment variables: ${missing.join(", ")}`,
+      },
+      { status: 500 }
+    );
+  }
+
+  const privateKey = privateKeyRaw!.replace(/\\n/g, "\n");
+
+  if (!clientEmail!.includes("@") || !privateKey.includes("BEGIN PRIVATE KEY")) {
+    return NextResponse.json(
+      { success: false, error: "Invalid Google API credentials" },
+      { status: 500 }
+    );
+  }
+
   try {
+    const auth = new google.auth.GoogleAuth({
+      credentials: {
+        client_email: clientEmail,
+        private_key: privateKey,
+      },
+      scopes: ["https://www.googleapis.com/auth/spreadsheets"],
+    });
+
+    const sheets = google.sheets({ version: "v4", auth });
+
     const body = await request.json();
     const { email, phone, description, testerProgram } = body;
 
     // First, get all existing values from the sheet
     const readResponse = await sheets.spreadsheets.values.get({
-      spreadsheetId: process.env.GOOGLE_SHEET_ID,
+      spreadsheetId: sheetId,
       range: "Sheet1!A:D", // Assuming columns A (email), B (phone), C (description), D (testerProgram)
     });
 
@@ -47,7 +76,7 @@ export async function POST(request: Request) {
 
     // If email and phone don't exist, append the new row
     const appendResponse = await sheets.spreadsheets.values.append({
-      spreadsheetId: process.env.GOOGLE_SHEET_ID,
+      spreadsheetId: sheetId,
       range: "Sheet1!A:D",
       valueInputOption: "USER_ENTERED",
       requestBody: {
@@ -55,9 +84,9 @@ export async function POST(request: Request) {
       },
     });
 
-    return NextResponse.json({ 
-      success: true, 
-      data: appendResponse.data 
+    return NextResponse.json({
+      success: true,
+      data: appendResponse.data
     });
   } catch (error) {
     console.error("Error processing sheet data:", error);


### PR DESCRIPTION
## Summary
- Initialize Google Sheets client inside the `POST` handler
- Validate required Google credentials and sheet ID before connecting
- Return informative errors for missing or malformed environment variables

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689698815c9c8333a5b6fffb35203df8